### PR TITLE
Add positive and negative SpO2 change multiplier + returned stable SpO2 value + Chest seal self treatment option

### DIFF
--- a/addons/breathing/ACE_Medical_Treatment_Actions.hpp
+++ b/addons/breathing/ACE_Medical_Treatment_Actions.hpp
@@ -56,7 +56,7 @@ class ACE_Medical_Treatment_Actions {
         category = "airway";
         treatmentLocations = 0;
         allowedSelections[] = {"Body"};
-        allowSelfTreatment = 0;
+        allowSelfTreatment = QGVAR(enable_selfChestseal);
         medicRequired = QGVAR(medLvl_Chestseal);
         treatmentTime = 7;
         items[] = {"kat_chestSeal"};

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -99,6 +99,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_settings_fnc_init;
 
+//Allow ChestSeal SelfTreatment
+[
+    QGVAR(enable_selfChestseal),
+    "LIST",
+    LLSTRING(SETTING_SELF_CHESTSEAL),
+    CBA_SETTINGS_CAT,
+    [[0, 1], ["STR_ACE_common_No", "STR_ACE_common_Yes"], 1],
+    true
+] call CBA_Settings_fnc_init;
+
 // % Chance of Hemopneumothorax
 [
     QGVAR(hemopneumothoraxChance),

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -58,6 +58,16 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
+// SpO2 value for stability determination
+[
+    QGVAR(Stable_spo2),
+    "SLIDER",
+    [LLSTRING(SETTING_STABLE_SPO2), LLSTRING(DESCRIPTION_STABLE_SPO2)],
+    CBA_SETTINGS_CAT,
+    [0, 95, 85, 0],
+    true
+] call CBA_Settings_fnc_init;
+
 // breathing probability for a pneumothorax
 // a pneumothorax is the presence of air or gas in the cavity between the lungs and the chest wall
 [

--- a/addons/breathing/XEH_preInit.sqf
+++ b/addons/breathing/XEH_preInit.sqf
@@ -38,13 +38,23 @@ PREP_RECOMPILE_END;
     true
 ] call CBA_Settings_fnc_init;
 
-// breathing SpO2 add & remove value small
+// breathing SpO2 add value
 [
-    QGVAR(SpO2_Multiply),
+    QGVAR(SpO2_MultiplyPositive),
     "SLIDER",
-    LLSTRING(SETTING_Multiply),
+    LLSTRING(SETTING_MultiplyPositive),
     CBA_SETTINGS_CAT,
-    [0, 3, 1, 1],
+    [0, 10, 1, 1],
+    true
+] call CBA_Settings_fnc_init;
+
+// breathing SpO2 remove value
+[
+    QGVAR(SpO2_MultiplyNegative),
+    "SLIDER",
+    LLSTRING(SETTING_MultiplyNegative),
+    CBA_SETTINGS_CAT,
+    [0, 10, 1, 1],
     true
 ] call CBA_Settings_fnc_init;
 

--- a/addons/breathing/functions/fnc_handleBreathing.sqf
+++ b/addons/breathing/functions/fnc_handleBreathing.sqf
@@ -43,7 +43,8 @@ if (!local _unit) then {
     private _heartRate = _unit getVariable ["ace_medical_heartRate", 0];
     private _output = 0;
     private _finalOutput;
-    private _multiplier = GVAR(SpO2_Multiply);
+    private _multiplierPositive = GVAR(SpO2_MultiplyPositive);
+    private _multiplierNegative = GVAR(SpO2_MultiplyNegative);
 
     //if lethal SpO2 value is activated and lower the value x, then kill _unit
     if ((_status <= GVAR(SpO2_dieValue)) && {GVAR(SpO2_dieActive)}) exitWith {
@@ -61,17 +62,17 @@ if (!local _unit) then {
 
     if !([_unit] call ace_common_fnc_isAwake) exitWith {
         if (_occluded == true || _obstruction == true) then {
-            _output = _output - (0.75 * _multiplier);
+            _output = _output - (0.75 * _multiplierNegative);
         } else {
-            _output = _output + (0.5 * _multiplier);
+            _output = _output + (0.5 * _multiplierPositive);
         };
 
         if (_pneumothorax == true || _hemothorax == true) then {
-            _output = _output - (0.75 * _multiplier);
+            _output = _output - (0.75 * _multiplierNegative);
         };
 
         if (_heartRate <= 40) then {
-            _output = -0.75 * _multiplier;
+            _output = -0.75 * _multiplierNegative;
         };
 
         _finalOutput = _status + _output;
@@ -90,10 +91,10 @@ if (!local _unit) then {
     if ([_unit] call ace_common_fnc_isAwake) exitWith {
         switch (true) do {
             case (true): {
-                _output = output + (0.5 * _multiplier);
+                _output = output + (0.5 * _multiplierPositive);
             };
             case (_pneumothorax == true || _hemothorax == true): {
-                _output = _output - (1 * _multiplier);
+                _output = _output - (1 * _multiplierNegative);
             };
         };
 

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -37,8 +37,11 @@
             <Turkish>Ölümcül SpO2 değerini etkinleştir</Turkish>
             <Italian>Attivare il valore letale di SpO2</Italian>
         </Key>
-        <Key ID="STR_kat_breathing_SETTING_Multiply">
-            <English>Multiplier for all SpO2 values.</English>
+        <Key ID="STR_kat_breathing_SETTING_MultiplyPositive">
+            <English>SpO2 positive multiplier</English>
+        </Key>
+	    <Key ID="STR_kat_breathing_SETTING_MultiplyNegative">
+            <English>SpO2 negative multiplier</English>
         </Key>
         <Key ID="STR_kat_breathing_SETTING_pneumothorax">
             <English>Probability for a pneumothorax</English>

--- a/addons/breathing/stringtable.xml
+++ b/addons/breathing/stringtable.xml
@@ -349,6 +349,9 @@
             <Turkish>Chest Seal kullanmak için gerekli eğitim seviyesi</Turkish>
             <Italian>Livello d'addestramento rischiesto per utilizzare il Chest Seal</Italian>
         </Key>
+	    <Key ID="STR_kat_breathing_SETTING_SELF_CHESTSEAL">
+            <English>Allow Chest Seal self treatment</English>
+        </Key>
         <Key ID="STR_kat_breathing_SETTING_STABLE_SPO2">
             <English>Stable SpO2 value to gain consciousness</English>
             <German>Stabiler SpO2-Wert, um Bewusstsein zu erlangen</German>


### PR DESCRIPTION
**When merged this pull request will:**
Add positive and negative SpO2 change multiplier so that users can set how fast will SpO2 value drop or raise independently on each other(Some communities would like the drop slower than the raise or even vice versa). Default value is set to 1 for both multipliers.

Also I have found out, that stable SpO2 value was somehow removed, so I returned it back. I've also added requested feature for Chest seal - possibility of self treatment via cba options.
